### PR TITLE
Add minimal infrastructure for launching the app

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,19 @@
+
+
+# application code
+
+## starting the app
+
+This section contains details on starting up the application. For now, we are using `docker-compose` for orchestration, just to speed up development.
+
+Kick up the app:
+
+```
+docker-compose up -d
+```
+
+Then check it out on `localhost:8080` in your browser.
+
+## references
+
+- https://github.com/juggernaut/nginx-flask-postgres-docker-compose-example

--- a/app/README.md
+++ b/app/README.md
@@ -6,13 +6,25 @@
 
 This section contains details on starting up the application. For now, we are using `docker-compose` for orchestration, just to speed up development.
 
+To rebuild any service containers:
+
+```
+docker-compose build
+```
+
 Kick up the app:
 
 ```
 docker-compose up -d
 ```
 
-Then check it out on `localhost:8080` in your browser.
+Then check it out on `localhost:5090` in your browser.
+
+Whenever you're done, shut down the app:
+
+```
+docker-compose down
+```
 
 ## references
 

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -18,6 +18,13 @@ services:
       - web_nw
     depends_on: 
       - flaskapp
+  elasticsearch:
+    image: "docker.elastic.co/elasticsearch/elasticsearch:5.4.3"
+    environment:
+      - "discovery.type=single-node"
+      - "xpack.security.enabled=false"
+    ports:
+      - "9200:9200"
 networks:
   web_nw:
     driver: bridge

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+services:
+  flaskapp:
+    build: 
+      context: ./ui
+      dockerfile: Dockerfile-ui
+    ports:
+      - "5090:5090"
+    networks:
+      - web_nw
+  nginx:
+    image: "nginx:1.13.5"
+    ports:
+      - "8080:80"
+    volumes:
+      - ./nginx:/etc/nginx/conf.d
+    networks:
+      - web_nw
+    depends_on: 
+      - flaskapp
+networks:
+  web_nw:
+    driver: bridge

--- a/app/nginx/flaskapp.conf
+++ b/app/nginx/flaskapp.conf
@@ -1,0 +1,14 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    location / {
+        proxy_set_header   Host                 $host;
+        proxy_set_header   X-Real-IP            $remote_addr;
+        proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto    $scheme;
+        proxy_set_header Host $http_host;
+
+        proxy_pass http://flaskapp:5090;
+    }
+}

--- a/app/ui/Dockerfile-ui
+++ b/app/ui/Dockerfile-ui
@@ -1,0 +1,17 @@
+FROM python:3
+MAINTAINER James Lamb <jaylamb20@gmail.com>
+
+ENV PYTHONUNBUFFERED 1
+
+# Copy Flask app stuff into the container
+RUN mkdir -p /opt/services/flaskapp/src
+ADD . /opt/services/flaskapp/src/
+EXPOSE 5090
+
+# Install deps
+RUN pip install Flask
+
+# Change dirs to wherever the flask code is
+WORKDIR /opt/services/flaskapp/src
+
+CMD python /opt/services/flaskapp/src/app.py

--- a/app/ui/app.py
+++ b/app/ui/app.py
@@ -1,0 +1,20 @@
+
+from flask import Flask
+from flask import render_template
+
+
+app = Flask(__name__)
+
+
+@app.route("/", methods=('GET', 'POST'))
+def signup():
+    return render_template('skills.html')
+
+
+@app.route("/success")
+def success():
+    return "Thank you for signing up!\n"
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5090, debug=True)

--- a/app/ui/templates/skills.html
+++ b/app/ui/templates/skills.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<head>
+  <title>skills</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+
+<body>
+    <h1> skills app </h1>
+    <p>
+        This is our first app. Oh my.
+    </p>
+
+    <img src="http://az505806.vo.msecnd.net/cms/5517349a-5b25-4a96-b448-5aa6fcae4e4f/6149fc81-69de-41cb-b91b-fd3b6716d88e.jpg">
+</body>


### PR DESCRIPTION
This PR defines a bare-bones implementation of a simple web app. I propose we use `docker-compose` for orchestration for at least the next week or so, since it's easy to test and iterate on. We can do something more sophisticated in the future if needed.