### PR TITLE
Service skeleton

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -2,6 +2,8 @@
 
 # application code
 
+This section of the repo holds all code needed to run the `skills` application. As of this writing, we are using `docker-compose` to handle all orchestration and networking between services.
+
 ## starting the app
 
 This section contains details on starting up the application. For now, we are using `docker-compose` for orchestration, just to speed up development.

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -8,6 +8,13 @@ services:
       - "5090:5090"
     networks:
       - web_nw
+  playground:
+    image: "jupyter/scipy-notebook"
+    ports:
+      - "5088:8888"
+    command: "start-notebook.sh --NotebookApp.token=''"
+    networks:
+      - web_nw
   nginx:
     image: "nginx:1.13.5"
     ports:
@@ -25,6 +32,8 @@ services:
       - "xpack.security.enabled=false"
     ports:
       - "9200:9200"
+    networks:
+      - web_nw
 networks:
   web_nw:
     driver: bridge

--- a/app/ingest_main/Dockerfile-ingest_main
+++ b/app/ingest_main/Dockerfile-ingest_main
@@ -1,0 +1,5 @@
+FROM python:3
+MAINTAINER James Lamb <jaylamb20@gmail.com>
+
+# TODO (jaylamb20@gmail.com):
+# Implement main ingestion service that reads from S3 and writes to our DB

--- a/app/ingest_main/README.md
+++ b/app/ingest_main/README.md
@@ -1,0 +1,4 @@
+
+# ingest_main
+
+This service is responsible for taking raw job description data stored in S3, converting them to our schema, and writing them to whatever we choose as a persistent store (Elasticsearch, for now).

--- a/app/ingest_raw/Dockerfile-ingest_raw
+++ b/app/ingest_raw/Dockerfile-ingest_raw
@@ -1,0 +1,5 @@
+FROM python:3
+MAINTAINER James Lamb <jaylamb20@gmail.com>
+
+# TODO (jaylamb20@gmail.com):
+# Implement raw data ingestion service to write to S3

--- a/app/ingest_raw/README.md
+++ b/app/ingest_raw/README.md
@@ -1,0 +1,6 @@
+
+# ingest_raw
+
+This service is responsible for taking raw job description data and storing it in an object store. For now, this is a public S3 bucket. This service is responsible for knowing the details of where we store data in its rawest form.
+
+All ETL code that hits data services (e.g. API calls, selenium scraping, other schemes) will send data to this thing.

--- a/app/playground/Dockerfile-playground
+++ b/app/playground/Dockerfile-playground
@@ -2,4 +2,4 @@ FROM python:3
 MAINTAINER James Lamb <jaylamb20@gmail.com>
 
 # TODO (jaylamb20@gmail.com):
-# Implement main ingestion service that reads from S3 and writes to our DB
+# Implement modeling playground (could later be replaced by Sagemaker)

--- a/app/playground/Dockerfile-playground
+++ b/app/playground/Dockerfile-playground
@@ -1,0 +1,5 @@
+FROM python:3
+MAINTAINER James Lamb <jaylamb20@gmail.com>
+
+# TODO (jaylamb20@gmail.com):
+# Implement main ingestion service that reads from S3 and writes to our DB

--- a/app/playground/README.md
+++ b/app/playground/README.md
@@ -1,0 +1,4 @@
+
+# playground
+
+This service just serves a Jupyter notebook in an environment with common modeling libraries. It is intended to be used by data scientists to train new candidate models entity resolution and / or job clustering.

--- a/app/scoring/Dockerfile-scoring
+++ b/app/scoring/Dockerfile-scoring
@@ -1,0 +1,7 @@
+FROM python:3
+MAINTAINER James Lamb <jaylamb20@gmail.com>
+
+# TODO (jaylamb20@gmail.com):
+# Implement service that takes in a description
+# of a person's credentials and returns a set of recommendations
+# to be presented in the UI

--- a/app/scoring/README.md
+++ b/app/scoring/README.md
@@ -1,0 +1,4 @@
+
+# scoring
+
+This service is responsible for taking in a description of someone's credentials and experience and returning a few suggestions to be used in the UI.


### PR DESCRIPTION
This PR defines a few of the services our application will need. It only introduces the basic repo skeleton for them, with one exception...the data science playground service will work as of this PR.

To try the "data science playground":

```
cd app/ && \
docker-compose build && \
docker-compose up -d
```

Then navigate to `localhost:5088` in your browser. You'll find a Jupyter server running there, and you can create notebooks within it. I tested and can confirm that you can save the notebooks out of the container to your local filesystem on your laptop.

This service can talk to `elasticsearch` at `http://elasticsearch:9200`, although there's not currently any data there. But making progress!

NOTE: I branched off #11 which was branched off #9 . Please review #9 and #10 , then I'll merge those and rebase. The purpose of doing this is to ensure that bundles of related changes end up in the same PR so we can use the PR history as a guide back through the project. I also hope that doing it will make it easier for you, the reviewers, to focus on the particular intent of each PR