### PR TITLE
Add Elasticsearch running on AWS

### DIFF
--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build: 
       context: ./ui
       dockerfile: Dockerfile-ui
+    environment:
+      - "ES_HOST=ec2-54-245-133-223.us-west-2.compute.amazonaws.com"
     ports:
       - "5090:5090"
     networks:
@@ -18,16 +20,19 @@ services:
       - web_nw
     depends_on: 
       - flaskapp
-  elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch:5.4.3"
-    environment:
-      - "discovery.type=single-node"
-      - "xpack.security.enabled=false"
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-    ports:
-      - "9200:9200"
-    networks:
-      - web_nw
+  
+  # NOTE: uncomment this block if you want to run a local
+  #       version of Elasticsearch
+  #elasticsearch:
+  #  image: "docker.elastic.co/elasticsearch/elasticsearch:5.4.3"
+  #  environment:
+  #    - "discovery.type=single-node"
+  #    - "xpack.security.enabled=false"
+  #    - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+  #  ports:
+  #    - "9200:9200"
+  #  networks:
+  #    - web_nw
 networks:
   web_nw:
     driver: bridge

--- a/app/elasticsearch/README.md
+++ b/app/elasticsearch/README.md
@@ -1,0 +1,52 @@
+
+# elasticsearch
+
+This section holds code used to configure and launch Elasticsearch on an AWS EC2 using the `CentOS 7 (x86_64)` AMI from the AWS Marketplace.
+
+## Spin up an instance
+
+To begin, go into the AWS console, navigate to "Instances", and create an instance using that AMI. Walk through the setup screens.
+
+- "Choose an Instance Type"
+    + `t2.large` is sufficient
+- "Configure Instance Details"
+    + just keep all the defaults
+- "Add Storage"
+    + add a 30GB EBS volume. Put it on `/dev/sdb`
+- "Configure Security Group"
+    + open ports w/ custom TCP protocols:
+        * 9200 (Elasticsearch HTTP default)
+        * 5601 (Kibana default)
+        * 80
+        * 8080
+
+## Log in
+
+Go to the AWS console and look for the public host on the instance. You can SSH into that box using that and the key file for the instance like this:
+
+```
+export EC2HOST='ec2-54-245-133-223.us-west-2.compute.amazonaws.com'
+ssh -i skills_app.pem "centos@${EC2HOST}"
+```
+
+If you get an error that says `WARNING: UNPROTECTED PRIVATE KEY FILE!`, do this:
+
+```
+chmod 0600 skills_app.pem
+```
+
+You should now be able to do stuff in the box. Be safe and have fun.
+
+## Setting up Elasticsearch for the first time
+
+All of the Elasticsearch configuration needed to get up and running is taken care of for you when running setup_instance.sh. That script will install Java and Elasticsearch. It will also overwrite the default Elasticsearch configuration files with those tuned to our setup in this project.
+
+## Starting Elasticsearch
+
+To start up ES, SSH into the box and run the following:
+
+```
+sudo /etc/init.d/elasticsearch start
+```
+
+

--- a/app/elasticsearch/elasticsearch.yml
+++ b/app/elasticsearch/elasticsearch.yml
@@ -1,0 +1,87 @@
+# ======================== Elasticsearch Configuration =========================
+#
+# NOTE: Elasticsearch comes with reasonable defaults for most settings.
+#       Before you set out to tweak and tune the configuration, make sure you
+#       understand what are you trying to accomplish and the consequences.
+#
+# The primary way of configuring a node is via this file. This template lists
+# the most important settings you may want to configure for a production cluster.
+#
+# Please consult the documentation for further information on configuration options:
+# https://www.elastic.co/guide/en/elasticsearch/reference/index.html
+#
+# ---------------------------------- Cluster -----------------------------------
+#
+# Use a descriptive name for your cluster:
+#
+cluster.name: skillsapp
+#
+# ------------------------------------ Node ------------------------------------
+#
+# Use a descriptive name for the node:
+node.name: ${HOSTNAME}
+#
+# Add custom attributes to the node:
+#
+#node.attr.rack: r1
+#
+# ----------------------------------- Paths ------------------------------------
+#
+# Path to directory where to store the data (separate multiple locations by comma):
+#
+path.data: /data/elasticsearch/data
+#
+# Path to log files:
+#
+path.logs: /data/elasticsearch/logs
+#
+# ----------------------------------- Memory -----------------------------------
+#
+# Lock the memory on startup:
+#
+#bootstrap.memory_lock: true
+#
+# Make sure that the heap size is set to about half the memory available
+# on the system and that the owner of the process is allowed to use this
+# limit.
+#
+# Elasticsearch performs poorly when the system is swapping the memory.
+#
+# ---------------------------------- Network -----------------------------------
+#
+# Set the bind address to a specific IP (IPv4 or IPv6):
+#
+network.host: ${HOSTNAME}
+#
+# Set a custom port for HTTP:
+#
+http.port: 9200
+#
+# For more information, consult the network module documentation.
+#
+# --------------------------------- Discovery ----------------------------------
+#
+# Pass an initial list of hosts to perform discovery when new node is started:
+# The default list of hosts is ["127.0.0.1", "[::1]"]
+#
+#discovery.zen.ping.unicast.hosts: ["elasticsearch1", "elasticsearch2", "elasticsearch3", "elasticsearch4"]
+#
+# Prevent the "split brain" by configuring the majority of nodes (total number of master-eligible nodes / 2 + 1):
+#
+#discovery.zen.minimum_master_nodes: 3
+#
+# For more information, consult the zen discovery module documentation.
+#
+# ---------------------------------- Gateway -----------------------------------
+#
+# Block initial recovery after a full cluster restart until N nodes are started:
+#
+#gateway.recover_after_nodes: 3
+#
+# For more information, consult the gateway module documentation.
+#
+# ---------------------------------- Various -----------------------------------
+#
+# Require explicit names when deleting indices:
+#
+#action.destructive_requires_name: true

--- a/app/elasticsearch/jvm.options
+++ b/app/elasticsearch/jvm.options
@@ -1,0 +1,111 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+-Xms4g
+-Xmx4g
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+
+## optimizations
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# force the server VM (remove on 32-bit client JVMs)
+-server
+
+# explicitly set the stack size (reduce to 320k on 32-bit client JVMs)
+-Xss1m
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# use old-style file permissions on JDK9
+-Djdk.io.permissionsUseCanonicalPath=true
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+-Dlog4j.skipJansi=true
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps
+# ensure the directory exists and has sufficient space
+#-XX:HeapDumpPath=${heap.dump.path}
+
+## GC logging
+
+#-XX:+PrintGCDetails
+#-XX:+PrintGCTimeStamps
+#-XX:+PrintGCDateStamps
+#-XX:+PrintClassHistogram
+#-XX:+PrintTenuringDistribution
+#-XX:+PrintGCApplicationStoppedTime
+
+# log GC status to a file with time stamps
+# ensure the directory exists
+#-Xloggc:${loggc}
+
+# By default, the GC log file will not rotate.
+# By uncommenting the lines below, the GC log file
+# will be rotated every 128MB at most 32 times.
+#-XX:+UseGCLogFileRotation
+#-XX:NumberOfGCLogFiles=32
+#-XX:GCLogFileSize=128M
+
+# Elasticsearch 5.0.0 will throw an exception on unquoted field names in JSON.
+# If documents were already indexed with unquoted fields in a previous version
+# of Elasticsearch, some operations may throw errors.
+#
+# WARNING: This option will be removed in Elasticsearch 6.0.0 and is provided
+# only for migration purposes.
+#-Delasticsearch.json.allow_unquoted_field_names=true

--- a/app/elasticsearch/setup.sh
+++ b/app/elasticsearch/setup.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+# Break immediately if anything fails
+set -e
+
+# Create a `/bin` dir at home
+if [ ! -d "$HOME/bin" ]; then
+  mkdir $HOME/bin
+fi
+
+######################################
+## Mount the attached storage drive ##
+######################################
+    
+    # Assumes we attached an EBS volume at /dev/xvdb. Let's
+    # add a mount point at /data
+    if [ ! -d "/data" ]; then
+  
+        cd $HOME
+
+        echo "Current state of disk mounts:"
+        lsblk 
+
+        echo "using drive " /dev/xvdb
+        echo "WARNING!! This will format the drive at" /dev/xvdb
+
+        # make a new ext4 filesystem on that EBS
+        sudo mkfs.ext4 /dev/xvdb
+
+        # mount the new filesystem under /data
+        sudo mkdir /data
+        sudo mount -t ext4 /dev/xvdb /data
+        sudo chmod a+rwx /data
+
+        sudo chown centos.centos -R /data
+
+        echo "Completed mounting EBS to /data. Check it out:"
+        lsblk
+    fi
+
+    # References:
+    # [1] https://docs.oracle.com/cloud/latest/computecs_common/OCSUG/GUID-7393768A-A147-444D-9D91-A56550604EE5.htm#OCSUG196
+
+#########
+## Git ##
+#########
+
+if ! type "git" &> /dev/null; then
+
+    echo "Installing Git..."
+
+    # Install Git
+    sudo yum install -y git-all
+
+    # References:
+    # [1] https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
+    echo "Completed installation of Git"
+fi
+
+
+#########################
+## Project source code ##
+#########################
+
+    # Get the source code
+    echo "Fetching application code from GitHub..."
+    cd $HOME && \
+    git clone https://github.com/shiftorg/skills && \
+    cd $HOME
+    echo "Completed fetching application code from GitHub."
+
+
+#############################
+## Misc. system components ##
+#############################
+
+    echo "Installing gcc, openssl, and libffi-devel..."
+    sudo yum install -y \
+        bzip2 \
+        gcc-c++ \
+        libffi-devel \
+        openssl-devel \
+        wget
+
+    echo "Completed installation of miscellanous system components."
+
+
+###################
+## Java (for ES) ##
+###################
+
+    echo "Installing Java...."
+    sudo yum install -y \
+        java-1.8.0-openjdk.x86_64
+
+    echo "Completed installation of Java."
+
+
+###################
+## Elasticsearch ##
+###################
+
+    echo "Installing Elasticsearch..."
+
+    # Download ES
+    export ES_VERSION=5.5.1
+    cd $HOME/bin && \
+    wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.rpm && \
+    sudo rpm --install elasticsearch-${ES_VERSION}.rpm && \
+    cd $HOME
+    echo "Completed installation of Elasticsearch."
+
+    # Create directories for ES to write data to (should be consistent with elasticsearch.yml)
+    sudo mkdir -p /data/elasticsearch/data
+    sudo mkdir -p /data/elasticsearch/logs
+
+    # Fix permissions. Yes I know this is gross but who cares it works
+    echo "Fixing permissions..."
+    sudo chown centos -R /etc/elasticsearch/
+    sudo chown centos -R /var/log/elasticsearch/
+    sudo chown centos -R /var/lib/elasticsearch/
+    sudo chown centos -R /usr/share/elasticsearch/
+    sudo chown centos -R /data/
+
+    sudo chmod 777 -R /etc/elasticsearch/
+    sudo chmod 777 -R /var/log/elasticsearch/
+    sudo chmod 777 -R /var/lib/elasticsearch/
+    sudo chmod 777 -R /usr/share/elasticsearch/
+    sudo chmod 777 -R /data/
+    echo "Done fixing permissions"
+
+    # Configure system to ES starts automatically on boot (useful if we have to restart)
+    echo "Registering Elasticsearch so it will start on boot..."
+    sudo systemctl daemon-reload
+    sudo systemctl enable elasticsearch.service
+    echo "Done registering Elasticseacrh."
+
+    # Copy over config
+    echo "Replacing default configurations with our own..."
+    
+    cp -f $HOME/skills/app/elasticsearch/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml
+    cp -f $HOME/skills/app/elasticsearch/jvm.options /etc/elasticsearch/jvm.options
+    sudo systemctl daemon-reload
+    echo "Done configuring Elasticsearch."
+
+    # References:
+    # [1] https://www.elastic.co/guide/en/elasticsearch/reference/current/rpm.html#install-rpm
+    # [2] https://www.digitalocean.com/community/tutorials/how-to-install-and-configure-elasticsearch-on-centos-7
+    # [3] https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+    # [4] https://github.com/elastic/elasticsearch/issues/21932

--- a/app/ui/README.md
+++ b/app/ui/README.md
@@ -38,3 +38,4 @@ For a detailed explanation on how things work, check out the [guide](http://vuej
 - [handling forms](https://012.vuejs.org/guide/forms.html)
 - [text input forms](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text)
 - [handling input data in flask](https://scotch.io/bar-talk/processing-incoming-request-data-in-flask#form-data)
+- [using bootstrap-vue](https://bootstrap-vue.js.org/docs/)

--- a/app/ui/app.py
+++ b/app/ui/app.py
@@ -4,12 +4,18 @@ from flask import jsonify
 from flask_cors import CORS
 from flask import request
 import random
+import os
+import requests
+import json
 
 app = Flask(__name__,
             static_folder="./frontend/dist/static",
             template_folder="./frontend/dist")
 
 cors = CORS(app, resources={r"/api/*": {"origins": "*"}})
+
+# Get global env vars
+ES_HOST = os.environ.get('ES_HOST')
 
 
 @app.route('/api/resume', methods=['POST'])
@@ -78,6 +84,19 @@ def get_data():
     return(jsonify(rand_jobs))
 
 
+@app.route('/about', defaults={'path': ''})
+def get_about(path):
+    return render_template("about.html")
+
+
+# Just testing that we can hit Elasticsearch
+@app.route('/es_health')
+def get_es_home():
+    response = requests.get("http://{}:9200".format(ES_HOST))
+    return(jsonify(json.loads(response.text)))
+
+
+@app.route('/home', defaults={'path': ''})
 @app.route('/', defaults={'path': ''}, methods=['GET', 'POST'])
 @app.route('/<path:path>')
 def catch_all(path):


### PR DESCRIPTION
This PR implements changes necessary to make the app work w/ Elasticsearch cluster running on AWS. For now, using a single-node cluster and still running the UI off localhost with `docker-compose`