### PR TITLE
Pointed ES ingestion code at AWS

### DIFF
--- a/app/ingestion/s3_jd.conf
+++ b/app/ingestion/s3_jd.conf
@@ -7,7 +7,7 @@ input {
         secret_access_key => "${S3_SECRET}"
         region => "us-east-1"
         bucket => "tech-salary-project"
-        prefix => "jds"
+        prefix => "jds_v3"
         interval => 2
         codec => "json"
     }

--- a/app/ingestion/seed_es.sh
+++ b/app/ingestion/seed_es.sh
@@ -3,7 +3,7 @@
 set -e
 
 # globals
-export ES_HOST="localhost:9200"
+export ES_HOST="ec2-54-245-133-223.us-west-2.compute.amazonaws.com:9200"
 
 # Upload mappings
 echo "Setting up mappings"


### PR DESCRIPTION
This PR changes our Logstash code to point ingestion at the VM I set up on AWS running ES5.5.

I haven't been able to confirm that it works yet because of permissions issues in S3. I was able to upload mappings, but not any data yet